### PR TITLE
BitConverterのサンプルを追加

### DIFF
--- a/src/Sazare.Common/Output.cs
+++ b/src/Sazare.Common/Output.cs
@@ -48,6 +48,14 @@
     }
 
     /// <summary>
+    /// 空行を出力します。
+    /// </summary>
+    public static void WriteLine()
+    {
+      WriteLine(string.Empty);
+    }
+
+    /// <summary>
     /// 指定されたデータを出力します。（改行付与有り）
     /// </summary>
     /// <param name="data">データ</param>
@@ -58,7 +66,7 @@
     }
 
     /// <summary>
-    /// 指定されたデータを出力います。（改行付与有り）
+    /// 指定されたデータを出力します。（改行付与有り）
     /// </summary>
     /// <param name="format">フォーマット</param>
     /// <param name="arg">フォーマット引数</param>

--- a/src/Sazare.Samples/Basic/BitConverterSamples02.cs
+++ b/src/Sazare.Samples/Basic/BitConverterSamples02.cs
@@ -9,19 +9,37 @@ namespace Sazare.Samples
   using Sazare.Samples.BitConverterSamples02_Extensions;
 
   #region BitConverterSamples-02
-
+  /// <summary>
+  /// System.BitConverterクラスのサンプルです。
+  /// </summary>
+  /// <remarks>
+  /// BitConverterがデフォルトでは対応していない
+  /// decimalとDateTimeのバイナリ化についてのサンプルです。
+  /// </remarks>
   public class BitConverterSamples02 : IExecutable
   {
     public void Execute()
     {
       var hexConverter = new Func<byte, string>(i => i.ToString("x"));
 
+      //
+      // decimal型のバイト列変換
+      //   decimal.GetBitsメソッドを使用することで
+      //   対象のdecimal値の内部表現をintの配列で取得できる。
+      //   後は、それをBitConverterを使ってバイト列にする。
+      //
       decimal.GetBits(decimal.MaxValue)
         .SelectMany(BitConverter.GetBytes)
         .JoinAndPrint(Output.WriteLine, hexConverter);
 
       Output.WriteLine();
 
+      //
+      // DateTimeのバイト列変換
+      //   DateTime.ToBinaryメソッドを使用することで
+      //   対象のDateTime値をlongで取得できる。
+      //   後は、それをBitConverterを使ってバイト列にする。
+      //
       BitConverter.GetBytes(DateTime.MaxValue.ToBinary())
         .JoinAndPrint(Output.WriteLine, hexConverter);
     }
@@ -34,8 +52,8 @@ namespace Sazare.Samples
       public static void JoinAndPrint<T>(this IEnumerable<T> self, Action<object> action, Func<T, string> hexConverter, string prefix = "0x")
       {
         var enumerable = self as T[] ?? self.ToArray();
-
         var queryHex = enumerable.Select(hexConverter);
+
         action(string.Join(" ", enumerable));
         action(string.Join(" ", queryHex));
       }

--- a/src/Sazare.Samples/Basic/BitConverterSamples02.cs
+++ b/src/Sazare.Samples/Basic/BitConverterSamples02.cs
@@ -1,0 +1,47 @@
+﻿// ReSharper disable once CheckNamespace
+namespace Sazare.Samples
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Linq;
+
+  using Sazare.Common;
+  using Sazare.Samples.BitConverterSamples02_Extensions;
+
+  #region BitConverterSamples-02
+
+  public class BitConverterSamples02 : IExecutable
+  {
+    public void Execute()
+    {
+      var hexConverter = new Func<byte, string>(i => i.ToString("x"));
+
+      decimal.GetBits(decimal.MaxValue)
+        .SelectMany(BitConverter.GetBytes)
+        .JoinAndPrint(Output.WriteLine, hexConverter);
+
+      Output.WriteLine();
+
+      BitConverter.GetBytes(DateTime.MaxValue.ToBinary())
+        .JoinAndPrint(Output.WriteLine, hexConverter);
+    }
+  }
+
+  namespace BitConverterSamples02_Extensions
+  {
+    public static class ListExtensions
+    {
+      public static void JoinAndPrint<T>(this IEnumerable<T> self, Action<object> action, Func<T, string> hexConverter, string prefix = "0x")
+      {
+        var enumerable = self as T[] ?? self.ToArray();
+
+        var queryHex = enumerable.Select(hexConverter);
+        action(string.Join(" ", enumerable));
+        action(string.Join(" ", queryHex));
+      }
+    }
+  }
+
+  #endregion
+
+}

--- a/src/Sazare.Samples/Sazare.Samples.csproj
+++ b/src/Sazare.Samples/Sazare.Samples.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Advanced\AssemblySamples01.cs" />
     <Compile Include="Basic\ArraySamples01.cs" />
     <Compile Include="Basic\ArraySegmentSamples01.cs" />
+    <Compile Include="Basic\BitConverterSamples02.cs" />
     <Compile Include="Basic\BufferSamples01.cs" />
     <Compile Include="Basic\CallerInformationSamples01.cs" />
     <Compile Include="Basic\CallerInformationSamples02.cs" />


### PR DESCRIPTION
BitConverterSamples02.csを追加

BitConverterがデフォルトでは対応していない
decimalとDateTimeのバイナリ化のサンプルを実装。